### PR TITLE
Added cucumber tests for moov-fintech

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - develop
+      - moov-fintech-devcon
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,13 @@
         <version>3.20.3</version>
     </parent>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <camel-version>3.20.3</camel-version>
         <portx-camel-lib.version>2.0.18</portx-camel-lib.version>
         <sentry.version>5.6.1</sentry.version>
         <atlassian.oai.validator.version>2.34.0</atlassian.oai.validator.version>
+        <cucumber.version>7.12.1</cucumber.version>
     </properties>
     <modelVersion>4.0.0</modelVersion>
 
@@ -85,7 +88,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M4</version>
+                    <version>3.1.2</version>
+                    <configuration>
+                        <rerunFailingTestsCount>0</rerunFailingTestsCount>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -386,6 +392,35 @@
             <artifactId>portx-api-schema-validator</artifactId>
             <version>0.0.6</version>
         </dependency> -->
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>${cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit-platform-engine</artifactId>
+            <version>${cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-spring</artifactId>
+            <version>${cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>2.27.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,7 +31,7 @@ endpoints:
     enabled: true
 
 mambu:
-  host: modusbox.sandbox.mambu.com
+  host: https://modusbox.sandbox.mambu.com
   username: shashi
   password: Modusbox@123
 

--- a/src/main/resources/camel/mambu.xml
+++ b/src/main/resources/camel/mambu.xml
@@ -37,7 +37,7 @@
             </datasonnet>
         </setBody>
         <log message="POST deposits transfer-transactions with request: ${body}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits/${exchangeProperty.depositAccountId}/transfer-transactions?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits/${exchangeProperty.depositAccountId}/transfer-transactions?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <to uri="direct:commonAPIResponseValidator"/>
         <log message="POST deposits transfer-transactions response is ${body}"/>
         <setProperty name="valueDate">
@@ -91,7 +91,7 @@
         <process ref="encodeAuthHeader" />
 
         <log message="GET deposits/transactions with id: ${header.paymentId}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits/transactions/${header.paymentId}?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits/transactions/${header.paymentId}?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <to uri="direct:commonAPIResponseValidator"/>
         <log message="GET deposits transactions response is ${body}"/>
         <setProperty name="debtorPaymentId">
@@ -111,7 +111,7 @@
         </setProperty>
 
         <log message="GET deposits/transactions with id: ${exchangeProperty.debtorPaymentId}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits/transactions/${exchangeProperty.debtorPaymentId}?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits/transactions/${exchangeProperty.debtorPaymentId}?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
         <log message="GET deposits transactions response is ${body}"/>
@@ -154,7 +154,7 @@
         <process ref="encodeAuthHeader" />
 
         <log message="GET branches request is ${body}"/>
-        <to uri="https://{{mambu.host}}/api/branches?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <to uri="{{mambu.host}}/api/branches?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
         <log message="GET branches response is ${body}"/>
@@ -181,7 +181,7 @@
         <process ref="encodeAuthHeader" />
 
         <log message="GET depositproducts request is ${body}"/>
-        <to uri="https://{{mambu.host}}/api/depositproducts?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <to uri="{{mambu.host}}/api/depositproducts?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
         <log message="GET depositproducts response is ${body}"/>
@@ -233,7 +233,7 @@
         </setBody>
         <log message="Find Person with request: ${body}"/>
         <log message="Find Persons"/>
-        <toD uri='https://{{mambu.host}}/api/clients&#x3A;search?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true'/>
+        <toD uri='{{mambu.host}}/api/clients&#x3A;search?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true'/>
         <to uri="direct:commonAPIResponseValidator"/>
         <log message="Find Person response is ${body}"/>
         <setBody>
@@ -264,7 +264,7 @@
         <process ref="encodeAuthHeader" />
 
         <log message="Find Person by Id with id: ${header.personId}"/>
-        <toD uri="https://{{mambu.host}}/api/clients/${header.personId}?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/clients/${header.personId}?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
         <log message="Find Person by Id response is ${body}"/>
@@ -300,7 +300,7 @@
             </datasonnet>
         </setBody>
         <log message="POST clients with request: ${body}"/>
-        <toD uri="https://{{mambu.host}}/api/clients?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/clients?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
         <log message="POST clients response is ${body}"/>
@@ -336,7 +336,7 @@
        </setBody>
 
        <log message="PUT clients with request: ${body}"/>
-       <toD uri="https://{{mambu.host}}/api/clients/${header.personId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+       <toD uri="{{mambu.host}}/api/clients/${header.personId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <to uri="direct:commonAPIResponseValidator"/>
        <log message="PUT clients response is ${body}"/>
        <setBody>
@@ -388,7 +388,7 @@
             </datasonnet>
         </setBody>
         <log message="POST deposit-transaction for account ${header.accountId} with request: ${body}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}/deposit-transactions?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits/${header.accountId}/deposit-transactions?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
         <log message="POST deposit-transaction response is ${body}"/>
@@ -439,7 +439,7 @@
         </datasonnet>
         </setBody>
         <log message="POST withdrawal-transaction for account ${header.accountId} with request: ${body}" />
-        <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}/withdrawal-transactions?throwExceptionOnFailure=false&amp;bridgeEndpoint=true" />
+        <toD uri="{{mambu.host}}/api/deposits/${header.accountId}/withdrawal-transactions?throwExceptionOnFailure=false&amp;bridgeEndpoint=true" />
 
         <to uri="direct:commonAPIResponseValidator"/>
         <log message="POST withdrawal-transaction response is ${body}" />
@@ -471,7 +471,7 @@
         <process ref="encodeAuthHeader" />
 
         <log message="GET deposits with id: ${header.accountId}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits/${header.accountId}?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <log message="Response code: ${header.CamelHttpResponseCode}"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
@@ -507,7 +507,7 @@
         <process ref="encodeAuthHeader" />
 
         <log message="GET deposits with id: ${header.accountId}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits/${header.accountId}?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
         <log message="GET deposits response is ${body}"/>
@@ -556,7 +556,7 @@
         <process ref="encodeAuthHeader" />
 
         <log message="GET all transactions for deposit account with id: ${header.accountId}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <log message="GET all transactions for deposit account with id: ${header.accountId} response is ${body}"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
@@ -591,7 +591,7 @@
             </datasonnet>
         </setProperty>
         <log message="GET all transactions for deposit account with id: ${header.accountId}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}/transactions?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits/${header.accountId}/transactions?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <log message="GET all transactions for deposit account with id: ${header.accountId} response is ${body}"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
@@ -622,7 +622,7 @@
         </setProperty>
         <process ref="encodeAuthHeader" />
         <log message="GET deposits with id: ${header.accountId}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <log message="GET deposits response is ${body}"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
@@ -654,7 +654,7 @@
         </setProperty>
         <process ref="encodeAuthHeader" />
         <log message="GET deposits with id: ${header.accountId}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <log message="GET deposits response is ${body}"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
@@ -686,7 +686,7 @@
         </setProperty>
         <process ref="encodeAuthHeader" />
         <log message="GET deposits with id: ${header.accountId}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <log message="GET deposits response is ${body}"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
@@ -719,7 +719,7 @@
         <process ref="encodeAuthHeader" />
 
         <log message="GET client with id: ${header.personId}"/>
-        <toD uri="https://{{mambu.host}}/api/clients/${header.personId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/clients/${header.personId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <log message="GET client response is ${body}"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
@@ -730,7 +730,7 @@
         </setProperty>
 
         <log message="GET deposits with id: ${header.personId}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits?accountHolderType=CLIENT&amp;accountHolderId=${header.personId}&amp;detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits?accountHolderType=CLIENT&amp;accountHolderId=${header.personId}&amp;detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <log message="GET deposits response is ${body}"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
@@ -763,7 +763,7 @@
         <process ref="encodeAuthHeader" />
 
         <log message="GET groups with id: ${header.organizationId}"/>
-        <toD uri="https://{{mambu.host}}/api/groups/${header.organizationId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/groups/${header.organizationId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <log message="GET groups response is ${body}"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
@@ -775,7 +775,7 @@
         </setProperty>
 
         <log message="GET deposits with id: ${header.organizationId}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits?accountHolderType=GROUP&amp;accountHolderId=${header.organizationId}&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits?accountHolderType=GROUP&amp;accountHolderId=${header.organizationId}&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <log message="GET deposits response is ${body}"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
@@ -824,7 +824,7 @@
             </datasonnet>
         </setBody>
         <log message="POST deposits with request: ${body}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
         <setProperty name="postDepositResponse">
@@ -848,7 +848,7 @@
             <constant>application/json</constant>
         </setHeader>
         <log message="POST deposits change state with request: ${body}"/>
-        <toD uri="https://{{mambu.host}}/api/deposits/${exchangeProperty.id}:changeState?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/deposits/${exchangeProperty.id}:changeState?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
         <log message="POST deposits change state response is ${body}"/>
@@ -925,7 +925,7 @@
                     <constant>application/json</constant>
                 </setHeader>
                 <log message="POST deposits deposit-transaction for account ${exchangeProperty.id} with request: ${body}"/>
-                <toD uri="https://{{mambu.host}}/api/deposits/${exchangeProperty.id}/deposit-transactions?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+                <toD uri="{{mambu.host}}/api/deposits/${exchangeProperty.id}/deposit-transactions?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
                 <to uri="direct:commonAPIResponseValidator"/>
                 <log message="POST deposits deposit-transaction response is ${body}"/>
             </when>
@@ -961,7 +961,7 @@
 <!--        <process ref="encodeAuthHeader" />-->
 
 <!--        <log message="PUT deposits with request: ${body}"/>-->
-<!--        <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>-->
+<!--        <toD uri="{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>-->
 <!--        <log message="PUT deposits response is ${body}"/>-->
 <!--        <to uri="direct:endRoute"/>-->
 <!--    </route>-->
@@ -985,7 +985,7 @@
             <constant>application/vnd.mambu.v2+json</constant>
         </setHeader>
         <log message="GET groups with id: ${header.organizationId}"/>
-        <toD uri="https://{{mambu.host}}/api/groups/${header.organizationId}?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/groups/${header.organizationId}?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <log message="GET groups response is ${body}"/>
 
         <to uri="direct:commonAPIResponseValidator"/>
@@ -1038,7 +1038,7 @@
             </datasonnet>
         </setBody>
         <log message="POST groups with request: ${body}"/>
-        <toD uri="https://{{mambu.host}}/api/groups?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
+        <toD uri="{{mambu.host}}/api/groups?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>
         <log message="POST groups response is ${body}"/>
         <to uri="direct:commonAPIResponseValidator"/>
         <setProperty name="originalBody">
@@ -1080,7 +1080,7 @@
 <!--        <process ref="encodeAuthHeader" />-->
 
 <!--        <log message="PUT groups with request: ${body}"/>-->
-<!--        <toD uri="https://{{mambu.host}}/api/groups/${header.personId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>-->
+<!--        <toD uri="{{mambu.host}}/api/groups/${header.personId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/>-->
 <!--        <log message="PUT groups response is ${body}"/>-->
 <!--        <to uri="direct:endRoute"/>-->
 <!--    </route>-->
@@ -1092,7 +1092,7 @@
         <setHeader name="CamelHttpMethod">
             <constant>POST</constant>
         </setHeader>
-        <to uri="https://{{mambu.host}}/api/branches"/>
+        <to uri="{{mambu.host}}/api/branches"/>
         <choice>
             <when>
                 <simple>${header.CamelHttpResponseCode} == 200</simple>
@@ -1118,7 +1118,7 @@
         <setHeader name="CamelHttpMethod">
             <constant>PUT</constant>
         </setHeader>
-        <to uri="https://{{mambu.host}}/api/branches/id"/>
+        <to uri="{{mambu.host}}/api/branches/id"/>
         <choice>
             <when>
                 <simple>${header.CamelHttpResponseCode} == 200</simple>
@@ -1187,7 +1187,7 @@
         <process ref="encodeAuthHeader" />
     
         <!-- <log message="GET depositproducts request is ${body}"/> -->
-        <!-- <to uri="https://{{mambu.host}}/api/depositproducts?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <to uri="{{mambu.host}}/api/depositproducts?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <setBody>
             <datasonnet bodyMediaType="application/json" outputMediaType="application/json" resultType="java.lang.String">
                 resource:classpath:mappings/perf/getProductResponse.ds
@@ -1228,7 +1228,7 @@
             </datasonnet>
         </setBody>
     
-        <!-- <toD uri="https://{{mambu.host}}/api/clients/${header.personId}?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/clients/${header.personId}?detailsLevel=FULL&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="GET clients response is ${body}"/> -->
         <setBody>
             <datasonnet bodyMediaType="application/json" outputMediaType="application/json" resultType="java.lang.String">
@@ -1268,7 +1268,7 @@
             </datasonnet>
         </setBody>
     
-        <!-- <toD uri="https://{{mambu.host}}/api/clients?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/clients?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="POST clients response is ${body}"/> -->
         <setBody>
             <datasonnet bodyMediaType="application/json" outputMediaType="application/json" resultType="java.lang.String">
@@ -1308,7 +1308,7 @@
         </datasonnet>
        </setBody>
     
-       <!-- <toD uri="https://{{mambu.host}}/api/clients/${header.personId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+       <!-- <toD uri="{{mambu.host}}/api/clients/${header.personId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
        <!-- <log message="PUT clients response is ${body}"/> -->
        <setBody>
             <datasonnet bodyMediaType="application/json" outputMediaType="application/json" resultType="java.lang.String">
@@ -1343,7 +1343,7 @@
         </setBody>
         
         <!-- <log message="GET deposits with id: ${header.accountId}"/> -->
-        <!-- <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="GET deposits response is ${body}"/> -->
         <setBody>
             <datasonnet bodyMediaType="application/json" outputMediaType="application/json" resultType="java.lang.String">
@@ -1383,7 +1383,7 @@
             </datasonnet>
         </setBody>
         
-        <!-- <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="GET deposits response is ${body}"/> -->
         <setBody>
             <datasonnet bodyMediaType="application/json" outputMediaType="application/json" resultType="java.lang.String">
@@ -1435,7 +1435,7 @@
             </datasonnet>
         </setBody>
     
-        <!-- <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}/transactions?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/deposits/${header.accountId}/transactions?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="GET all transactions for deposit account with id: ${header.accountId} response is ${body}"/> -->
         
     </route>
@@ -1464,7 +1464,7 @@
                 resource:classpath:mappings/perf/getDepositResponse.ds
             </datasonnet>
         </setBody>    
-        <!-- <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="GET deposits response is ${body}"/> -->
         <setBody>
             <datasonnet bodyMediaType="application/json" outputMediaType="application/json" resultType="java.lang.String">
@@ -1500,7 +1500,7 @@
             </datasonnet>
         </setBody>    
     
-        <!-- <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="GET deposits response is ${body}"/> -->
         <setBody>
             <datasonnet bodyMediaType="application/json" outputMediaType="application/json" resultType="java.lang.String">
@@ -1536,7 +1536,7 @@
             </datasonnet>
         </setBody>    
     
-        <!-- <toD uri="https://{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/deposits/${header.accountId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="GET deposits response is ${body}"/> -->
         <setBody>
             <datasonnet bodyMediaType="application/json" outputMediaType="application/json" resultType="java.lang.String">
@@ -1573,7 +1573,7 @@
             </datasonnet>
         </setBody>    
     
-        <!-- <toD uri="https://{{mambu.host}}/api/clients/${header.personId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/clients/${header.personId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="GET clients response is ${body}"/> -->
     
         <setProperty name="clientName">
@@ -1589,7 +1589,7 @@
             </datasonnet>
         </setBody>    
     
-        <!-- <toD uri="https://{{mambu.host}}/api/deposits?accountHolderType=CLIENT&amp;accountHolderId=${header.personId}&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/deposits?accountHolderType=CLIENT&amp;accountHolderId=${header.personId}&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="GET deposits response is ${body}"/> -->
         <setBody>
             <datasonnet bodyMediaType="application/json" outputMediaType="application/json" resultType="java.lang.String">
@@ -1625,7 +1625,7 @@
                 resource:classpath:mappings/perf/getGroupResponse.ds
             </datasonnet>
         </setBody>   
-        <!-- <toD uri="https://{{mambu.host}}/api/groups/${header.organizationId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/groups/${header.organizationId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="GET groups response is ${body}"/> -->
     
         <setProperty name="clientName">
@@ -1640,7 +1640,7 @@
                 resource:classpath:mappings/perf/getDepositsResponse.ds
             </datasonnet>
         </setBody>  
-        <!-- <toD uri="https://{{mambu.host}}/api/deposits?accountHolderType=GROUP&amp;accountHolderId=${header.organizationId}&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/deposits?accountHolderType=GROUP&amp;accountHolderId=${header.organizationId}&amp;throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="GET deposits response is ${body}"/> -->
         <setBody>
             <datasonnet bodyMediaType="application/json" outputMediaType="application/json" resultType="java.lang.String">
@@ -1692,7 +1692,7 @@
                 resource:classpath:mappings/perf/createClientResponse.ds
             </datasonnet>
         </setBody>  
-        <!-- <toD uri="https://{{mambu.host}}/api/deposits?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/deposits?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <setProperty name="postDepositResponse">
             <simple>${body}</simple>
         </setProperty>
@@ -1719,7 +1719,7 @@
                 resource:classpath:mappings/perf/getDepositResponse.ds
             </datasonnet>
         </setBody>  
-        <!-- <toD uri="https://{{mambu.host}}/api/deposits/${exchangeProperty.id}:changeState?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/deposits/${exchangeProperty.id}:changeState?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="POST deposits change state response is ${body}"/> -->
         <setProperty name="accountState">
             <datasonnet bodyMediaType="application/json" outputMediaType="text/plain" resultType="java.lang.String">
@@ -1783,7 +1783,7 @@
                         resource:classpath:mappings/perf/postDepositTransactionResponse.ds
                     </datasonnet>
                 </setBody>  
-                <!-- <toD uri="https://{{mambu.host}}/api/deposits/${exchangeProperty.id}/deposit-transactions?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+                <!-- <toD uri="{{mambu.host}}/api/deposits/${exchangeProperty.id}/deposit-transactions?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
                 <!-- <log message="POST deposits deposit-transaction response is ${body}"/> -->
             </when>
             <otherwise>
@@ -1822,7 +1822,7 @@
             </datasonnet>
         </setBody>   
     
-        <!-- <toD uri="https://{{mambu.host}}/api/groups/${header.organizationId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/groups/${header.organizationId}?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="GET groups response is ${body}"/> -->
     
     </route>
@@ -1856,7 +1856,7 @@
             </datasonnet>
         </setBody>   
     
-        <!-- <toD uri="https://{{mambu.host}}/api/groups?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
+        <!-- <toD uri="{{mambu.host}}/api/groups?throwExceptionOnFailure=false&amp;bridgeEndpoint=true"/> -->
         <!-- <log message="POST groups response is ${body}"/> -->
         
     </route>

--- a/src/main/resources/mappings/findPersonByIdResponse.ds
+++ b/src/main/resources/mappings/findPersonByIdResponse.ds
@@ -86,8 +86,8 @@ std.prune({
   "taxInformation": taxInformation,
   "audit" : {
     "status": selector(payload, "state"),
-    "creationDate": selector(payload, "creationDate"),
-    "lastModificationDate": selector(payload, "lastModifiedDate"),
+    "creationDate": if selector(payload, "creationDate") != null then ds.datetime.toLocalDate(selector(payload, "creationDate")),
+    "lastModificationDate": if selector(payload, "lastModifiedDate") != null then ds.datetime.toLocalDate(selector(payload, "lastModifiedDate")),
   }
 })
 

--- a/src/test/java/io/portx/cbs/connector/CucumberFeatureTest.java
+++ b/src/test/java/io/portx/cbs/connector/CucumberFeatureTest.java
@@ -1,0 +1,18 @@
+package io.portx.cbs.connector;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.Suite;
+
+import static io.cucumber.junit.platform.engine.Constants.*;
+
+
+@Suite
+@IncludeEngines("cucumber")
+@ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty, html:target/cucumber-reports/Cucumber.html, " +
+        "json:target/cucumber-reports/Cucumber.json, junit:target/cucumber-reports/Cucumber.xml")
+@ConfigurationParameter(key = FEATURES_PROPERTY_NAME, value = "src/test/resources/io/portx/cbs/connector/cucumber")
+@ConfigurationParameter(key = JUNIT_PLATFORM_NAMING_STRATEGY_PROPERTY_NAME, value = "long")
+@ConfigurationParameter(key = PLUGIN_PUBLISH_ENABLED_PROPERTY_NAME, value = "false")
+public class CucumberFeatureTest {
+}

--- a/src/test/java/io/portx/cbs/connector/cucumber/CucumberTestDefinition.java
+++ b/src/test/java/io/portx/cbs/connector/cucumber/CucumberTestDefinition.java
@@ -1,0 +1,52 @@
+package io.portx.cbs.connector.cucumber;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.cucumber.spring.CucumberContextConfiguration;
+import io.portx.cbs.connector.Application;
+import io.portx.cbs.connector.cucumber.util.GsonBuilderUtil;
+import io.portx.cbs.connector.cucumber.util.RestHttpRequestFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@CucumberContextConfiguration
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+        properties = {
+                "server.port=8042"
+        }, classes = {Application.class})
+@ActiveProfiles("cucumber")
+public class CucumberTestDefinition {
+
+    protected static final String BASE_PATH = "/mambu-portx-cbs-connector/1.0";
+    protected static String LOCALHOST_URL = "http://localhost:8042" + BASE_PATH;
+    protected Gson gson = GsonBuilderUtil.getGson();
+    protected RestHttpRequestFactory restFactory = new RestHttpRequestFactory();
+
+    /**
+     * Extracts a value from a JSON structure using Gson.
+     *
+     * @param json      The JSON string containing the data.
+     * @param fieldName The name of the field to extract the value of.
+     * @return The extracted value as a string.
+     * @throws IllegalArgumentException If the field is not found or an error occurs.
+     */
+    protected String extractValueFromJson(String json, String fieldName) {
+        try {
+            JsonElement rootElement = JsonParser.parseString(json);
+            if (rootElement.isJsonObject()) {
+                JsonObject jsonObject = rootElement.getAsJsonObject();
+                if (jsonObject.has(fieldName)) {
+                    return jsonObject.get(fieldName).getAsString();
+                } else {
+                    throw new IllegalArgumentException("Field '" + fieldName + "' not found in the JSON");
+                }
+            }
+            throw new IllegalArgumentException("Invalid JSON structure");
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Error while extracting value from JSON: " + e.getMessage());
+        }
+    }
+
+}

--- a/src/test/java/io/portx/cbs/connector/cucumber/PersonCucumberTestDefinition.java
+++ b/src/test/java/io/portx/cbs/connector/cucumber/PersonCucumberTestDefinition.java
@@ -1,0 +1,109 @@
+package io.portx.cbs.connector.cucumber;
+
+
+import com.atlassian.oai.validator.model.Request;
+import io.cucumber.java.AfterAll;
+import io.cucumber.java.BeforeAll;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.portx.camel.test.util.TestResourceReader;
+import io.portx.cbs.connector.Person;
+import io.portx.cbs.connector.PersonRequest;
+import io.portx.cbs.connector.cucumber.util.OpenApiResponseValidator;
+import io.portx.cbs.connector.cucumber.util.WiremockFactory;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.http.HttpResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class PersonCucumberTestDefinition extends CucumberTestDefinition {
+    private Person findPersonByIdResponse;
+    private Person createPersonResponse;
+    private String payload;
+    private HttpResponse<String> personCreationResponse;
+    private HttpResponse<String> findPersonResponse;
+    public static String personIdCreated;
+
+    @BeforeAll
+    public static void beforeAll() {
+        WiremockFactory.init();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        WiremockFactory.stop();
+    }
+
+    /**
+     * Scenario: Create a Person
+     */
+    @Given("I have the person payload located at {string} that I want to create a person")
+    public void readPayloadFromPath(String path) throws URISyntaxException, IOException {
+        payload = TestResourceReader
+                .readFileAsString(path);
+    }
+
+    @When("I create a person using the API")
+    public void requestCreatePerson() throws URISyntaxException, IOException, JSONException {
+        personCreationResponse = restFactory.post(LOCALHOST_URL + "/persons", payload);
+        JSONAssert.assertEquals(personCreationResponse.body(), TestResourceReader
+                        .readFileAsString("test-data/json/mambuAPI/create-person/createPersonResponseOBA.json"),
+                JSONCompareMode.STRICT);
+        personIdCreated = extractValueFromJson(personCreationResponse.body(), "personId");
+    }
+
+    @Then("I check that the status code coming from the API response is {string}")
+    public void checkResponseHttpStatus(String httpStatus) {
+        assertEquals(Integer.valueOf(httpStatus), personCreationResponse.statusCode());
+    }
+
+    @And("I validate that the API response has the required fields using the validation rules engine")
+    public void validateCreatePersonAPIResponse() {
+        OpenApiResponseValidator
+                .validateResponseAgainstSwaggerConstraints("/persons",
+                        Request.Method.POST,
+                        personCreationResponse);
+
+    }
+
+    @And("I get the person id")
+    public void findPersonCreatedById() {
+        findPersonResponse = restFactory.get(LOCALHOST_URL + "/persons/" + personIdCreated);
+        findPersonByIdResponse = gson.fromJson(findPersonResponse.body(), Person.class);
+        assertNotNull(findPersonByIdResponse);
+    }
+
+    @And("I validate that the fields on the requests are present on the response")
+    public void validatePersonRequestWithPersonResponse() throws JSONException {
+        JSONAssert.assertEquals(personCreationResponse.body(), findPersonResponse.body(), JSONCompareMode.STRICT);
+    }
+
+    /**
+     * Scenario: Retrieve a Person
+     */
+    @When("I retrieve a person with the id {string} using the API")
+    public void findPersonById(String personId) {
+        findPersonResponse = restFactory.get(LOCALHOST_URL + "/persons/" + personId);
+        assertNotNull(findPersonResponse.body());
+    }
+    @Then("I check that the status code coming from getPerson from the API response is {string}")
+    public void checkResponseGetPersonHttpStatus(String httpStatus) {
+        assertEquals(Integer.valueOf(httpStatus), findPersonResponse.statusCode());
+    }
+
+    @And("I validate that the API response from findPerson has the required fields using the validation rules engine")
+    public void validateFindPersonAPIResponse() {
+        OpenApiResponseValidator
+                .validateResponseAgainstSwaggerConstraints("/persons/{personId}",
+                        Request.Method.GET,
+                        findPersonResponse);
+    }
+}

--- a/src/test/java/io/portx/cbs/connector/cucumber/util/GsonBuilderUtil.java
+++ b/src/test/java/io/portx/cbs/connector/cucumber/util/GsonBuilderUtil.java
@@ -1,0 +1,26 @@
+package io.portx.cbs.connector.cucumber.util;
+
+import com.google.gson.*;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class GsonBuilderUtil {
+
+    private static final Gson gson = new GsonBuilder()
+            .registerTypeAdapter(LocalDate.class, (JsonSerializer<LocalDate>) (date, type, context) ->
+                    new JsonPrimitive(date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))))
+            .registerTypeAdapter(OffsetDateTime.class, (JsonSerializer<OffsetDateTime>) (dateTime, type, context) ->
+                    new JsonPrimitive(dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssX"))))
+            .registerTypeAdapter(LocalDate.class, (JsonDeserializer<LocalDate>) (json, type, jsonDeserializationContext) ->
+                    LocalDate.parse(json.getAsJsonPrimitive().getAsString()))
+            .registerTypeAdapter(OffsetDateTime.class, (JsonDeserializer<OffsetDateTime>) (json, type, context) ->
+                    OffsetDateTime.parse(json.getAsJsonPrimitive().getAsString(), DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssX")))
+            .create();
+
+
+    public static Gson getGson() {
+        return gson;
+    }
+}

--- a/src/test/java/io/portx/cbs/connector/cucumber/util/OpenApiResponseValidator.java
+++ b/src/test/java/io/portx/cbs/connector/cucumber/util/OpenApiResponseValidator.java
@@ -1,0 +1,50 @@
+package io.portx.cbs.connector.cucumber.util;
+
+import com.atlassian.oai.validator.OpenApiInteractionValidator;
+import com.atlassian.oai.validator.model.Request;
+import com.atlassian.oai.validator.model.Response;
+import com.atlassian.oai.validator.model.SimpleResponse;
+import com.atlassian.oai.validator.report.LevelResolver;
+import com.atlassian.oai.validator.report.ValidationReport;
+import io.portx.camel.exception.ValidationException;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpResponse;
+
+public abstract class OpenApiResponseValidator {
+
+    private static final String DEFAULT_SWAGGER_YAML = "swagger.yaml";
+
+    public static void validateResponseAgainstSwaggerConstraints(String endpoint,
+                                                                 Request.Method httpMethod,
+                                                                 HttpResponse<String> httpResponse){
+        InputStream mappingStream = OpenApiResponseValidator.class
+                .getClassLoader().getResourceAsStream(DEFAULT_SWAGGER_YAML);
+        String yamlSpec;
+        try {
+            yamlSpec = IOUtils.toString(mappingStream, "UTF-8");
+            mappingStream.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        OpenApiInteractionValidator validator = OpenApiInteractionValidator.createForInlineApiSpecification(yamlSpec)
+                .withLevelResolver(LevelResolver.create()
+                        .withLevel("validation.schema.required", ValidationReport.Level.ERROR)
+                        .build()).build();
+        Response response = buildAtlassianResponse(httpResponse);
+        ValidationReport validationReport = validator.validateResponse(endpoint, httpMethod, response);
+        if (validationReport.hasErrors()) {
+            throw new ValidationException(validationReport);
+        }
+    }
+
+    private static Response buildAtlassianResponse(HttpResponse<String> httpResponse) {
+        SimpleResponse.Builder builder = SimpleResponse.Builder
+                .status(httpResponse.statusCode())
+                .withBody(httpResponse.body());
+        httpResponse.headers().map().forEach(builder::withHeader);
+        return builder.build();
+    }
+}

--- a/src/test/java/io/portx/cbs/connector/cucumber/util/RestHttpRequestFactory.java
+++ b/src/test/java/io/portx/cbs/connector/cucumber/util/RestHttpRequestFactory.java
@@ -1,0 +1,241 @@
+package io.portx.cbs.connector.cucumber.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClientException;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+
+/**
+ * Utility class for creating and sending REST HTTP requests.
+ */
+public class RestHttpRequestFactory {
+
+    private Gson gson = GsonBuilderUtil.getGson();
+    private final HttpClient httpClient;
+
+    public RestHttpRequestFactory() {
+        SSLContext sslContext = null;
+        try {
+            // Load your keystore
+            KeyStore keyStore = KeyStore.getInstance("JKS");
+            try (InputStream inputStream = WiremockFactory.class.getResourceAsStream("/wiremock/https/key/keystore.jks")) {
+                keyStore.load(inputStream, "password".toCharArray());
+            }
+
+            // Load the certificate from the keystore
+            X509Certificate certificate = (X509Certificate) keyStore.getCertificate("myalias");
+
+            // Create a TrustManager that trusts the certificate
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(keyStore);
+
+            // Create an SSL context that trusts the certificate
+            sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, trustManagerFactory.getTrustManagers(), new java.security.SecureRandom());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        httpClient = HttpClient.newBuilder()
+                .sslContext(sslContext)
+                .version(HttpClient.Version.HTTP_2)
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    /**
+     * Sends an HTTP GET request to the specified URL and returns the deserialized response.
+     *
+     * @param httpUrl      the URL to send the GET request to
+     * @param responseType the class of the response type to deserialize the response to
+     * @param <T>          the type of the response
+     * @return the deserialized response object
+     * @throws RestClientException if an unexpected response or error occurs
+     */
+    public <T> T get(String httpUrl, Class<T> responseType) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(httpUrl))
+                .setHeader("User-Agent", "Java 11 HttpClient")
+                .header("Content-Type", "application/json")
+                .GET()
+                .build();
+        HttpResponse<String> httpResponse = null;
+        try {
+            httpResponse = this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            resolveHttpResponseStatus(httpResponse);
+        } catch (Throwable e) {
+            failTest(e, request.uri().getPath());
+        }
+        return parseResponseBody(responseType, request, httpResponse);
+    }
+
+    /**
+     * Sends an HTTP GET request to the specified URL and returns the deserialized response.
+     *
+     * @param httpUrl      the URL to send the GET request to
+     * @return the deserialized response object
+     * @throws RestClientException if an unexpected response or error occurs
+     */
+    public HttpResponse<String> get(String httpUrl) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(httpUrl))
+                .setHeader("User-Agent", "Java 11 HttpClient")
+                .header("Content-Type", "application/json")
+                .GET()
+                .build();
+        HttpResponse<String> httpResponse = null;
+        try {
+            httpResponse = this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            resolveHttpResponseStatus(httpResponse);
+        } catch (Throwable e) {
+            failTest(e, request.uri().getPath());
+        }
+        return httpResponse;
+    }
+
+
+    /**
+     * Sends an HTTP GET request with a custom request object and returns the deserialized response.
+     *
+     * @param request      the custom HttpRequest object representing the GET request
+     * @param responseType the class of the response type to deserialize the response to
+     * @param <T>          the type of the response
+     * @return the deserialized response object
+     * @throws RestClientException if an unexpected response or error occurs
+     */
+    public <T> T get(HttpRequest request, Class<T> responseType) {
+        HttpResponse<String> httpResponse = null;
+        try {
+            httpResponse = this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            resolveHttpResponseStatus(httpResponse);
+        } catch (Throwable e) {
+            failTest(e, request.uri().getPath());
+        }
+        return parseResponseBody(responseType, request, httpResponse);
+    }
+
+    /**
+     * Sends an HTTP POST request to the specified URL with the given JSON body and returns the deserialized response.
+     *
+     * @param httpUrl       the URL to send the POST request to
+     * @param jsonBody      the JSON body of the request
+     * @param responseType the class of the response type to deserialize the response to
+     * @param <T>           the type of the response
+     * @return the deserialized response object
+     * @throws RestClientException if an unexpected response or error occurs
+     */
+    public <T> T post(String httpUrl, String jsonBody, Class<T> responseType) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(httpUrl))
+                .setHeader("User-Agent", "Java 11 HttpClient")
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+                .build();
+        HttpResponse<String> httpResponse = null;
+        try {
+            httpResponse = this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            resolveHttpResponseStatus(httpResponse);
+        } catch (Throwable e) {
+            failTest(e, httpUrl);
+        }
+        return parseResponseBody(responseType, request, httpResponse);
+    }
+
+    /**
+     * Sends an HTTP POST request to the specified URL with the given JSON body and returns the deserialized response.
+     *
+     * @param httpUrl       the URL to send the POST request to
+     * @param jsonBody      the JSON body of the request
+     * @return the deserialized response object
+     * @throws RestClientException if an unexpected response or error occurs
+     */
+    public HttpResponse post(String httpUrl, String jsonBody) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(httpUrl))
+                .setHeader("User-Agent", "Java 11 HttpClient")
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+                .build();
+        HttpResponse<String> httpResponse = null;
+        try {
+            httpResponse = this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (Throwable e) {
+            failTest(e, httpUrl);
+        }
+        return httpResponse;
+    }
+
+    /**
+     * Resolves the HTTP response and handles any errors or unexpected responses.
+     *
+     * @param httpResponse the HTTP response to resolve
+     * @throws HttpClientErrorException if the response status code indicates a client error
+     * @throws HttpServerErrorException if the response status code indicates a server error
+     * @throws RestClientException     if the response status code is unexpected
+     */
+    private void resolveHttpResponseStatus(HttpResponse<String> httpResponse) {
+        int statusCode = httpResponse.statusCode();
+        if (statusCode < 200 || statusCode >= 300) {
+            if (statusCode >= 400 && statusCode < 500) {
+                throw new HttpClientErrorException(HttpStatus.resolve(statusCode), "Client error: "
+                        + httpResponse.body() + " URI: " + httpResponse.request().uri());
+            } else if (statusCode >= 500 && statusCode < 600) {
+                throw new HttpServerErrorException(HttpStatus.resolve(statusCode), "Server error: "
+                        + httpResponse.body() + " URI: " + httpResponse.request().uri());
+            } else {
+                throw new RestClientException("Unexpected response: " + httpResponse.body()
+                        + " URI: " + httpResponse.request().uri());
+            }
+        }
+    }
+
+    /**
+     * Parses the response body of an HTTP request and deserializes it to the specified response type.
+     *
+     * @param responseType the class of the response type to deserialize the response to
+     * @param request      the original HTTP request
+     * @param httpResponse the HTTP response containing the response body to parse
+     * @param <T>          the type of the response
+     * @return the deserialized response object
+     * @throws RestClientException if an error occurs during parsing or deserialization
+     */
+    private <T> T parseResponseBody(Class<T> responseType, HttpRequest request, HttpResponse<String> httpResponse) {
+        T deserializedResponse = null;
+        try {
+            deserializedResponse = gson.fromJson(httpResponse.body(), responseType);
+        } catch (JsonSyntaxException e) {
+            failTest(e, request.uri().getPath());
+        } catch (Throwable e) {
+            failTest(e, request.uri().getPath());
+        }
+        return deserializedResponse;
+    }
+
+    /**
+     * Handles the failure of a test by printing the stack trace of the exception and failing the test with a specific message.
+     *
+     * @param e       the Throwable object representing the exception that occurred
+     * @param request the URL of the request that caused the failure
+     */
+    private static void failTest(Throwable e, String request) {
+        e.printStackTrace();
+        fail("Step failed: I tried to make a request to the URL: " + request + " but I received an error :: " + e.getMessage());
+    }
+}

--- a/src/test/java/io/portx/cbs/connector/cucumber/util/WiremockFactory.java
+++ b/src/test/java/io/portx/cbs/connector/cucumber/util/WiremockFactory.java
@@ -1,0 +1,68 @@
+package io.portx.cbs.connector.cucumber.util;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import io.portx.camel.test.util.TestResourceReader;
+import wiremock.org.apache.commons.lang3.exception.ExceptionUtils;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class WiremockFactory {
+
+    private static final Logger logger = Logger.getLogger(WiremockFactory.class.getName());
+    private static final String CREATE_PERSON_REQUEST_MAMBU = "test-data/json/mambuAPI/create-person/createPersonRequestMambu.json";
+    private static final String CREATE_PERSON_RESPONSE_MAMBU = "test-data/json/mambuAPI/create-person/createPersonResponseMambu.json";
+    private static final String FIND_PERSON_BY_ID_RESPONSE_MAMBU = "test-data/json/mambuAPI/find-person/findPersonResponseMambu.json";
+    public static final StringValuePattern MAMBU_AUTHORIZATION_TOKEN = WireMock.equalTo("Basic dGVzdDp0ZXN0");
+    public static final StringValuePattern MAMBU_HEADER = WireMock.equalTo("application/vnd.mambu.v2+json");
+    private static WireMockServer wireMockServer;
+    private static final int WIREMOCK_PORT = 8043;
+    public static void init() {
+        wireMockServer =  new WireMockServer(WIREMOCK_PORT);
+        wireMockServer.start();
+        WireMock.configureFor(WIREMOCK_PORT);
+        createWiremockResponsesForMambuIntegration();
+    }
+
+
+    public static void stop() {
+        wireMockServer.stop();
+    }
+
+    private static void createWiremockResponsesForMambuIntegration() {
+        try {
+            // Mock requests and responses
+            WireMock.stubFor(WireMock.post(WireMock.urlEqualTo("/api/clients"))
+                    .withHeader("Authorization", MAMBU_AUTHORIZATION_TOKEN)
+                    .withHeader("Accept", MAMBU_HEADER)
+                    .withRequestBody(WireMock.equalToJson(TestResourceReader
+                            .readFileAsString(CREATE_PERSON_REQUEST_MAMBU)))
+                    .willReturn(WireMock.aResponse()
+                            .withStatus(202)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(TestResourceReader
+                                    .readFileAsString(CREATE_PERSON_RESPONSE_MAMBU))));
+            WireMock.stubFor(WireMock.get(WireMock.urlPathMatching("/api/clients/12345"))
+                    .willReturn(WireMock.aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(TestResourceReader
+                                    .readFileAsString(FIND_PERSON_BY_ID_RESPONSE_MAMBU))));
+        } catch (URISyntaxException e) {
+            logger.log(Level.SEVERE, "An error occurred:", ExceptionUtils.getStackTrace(e));
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "An error occurred:", ExceptionUtils.getStackTrace(e));
+            throw new RuntimeException(e);
+        } catch (RuntimeException ex) {
+            logger.log(Level.SEVERE, "An error occurred:", ExceptionUtils.getStackTrace(ex));
+            throw new RuntimeException(ex);
+        }
+    }
+
+}

--- a/src/test/resources/application-cucumber.yml
+++ b/src/test/resources/application-cucumber.yml
@@ -1,0 +1,7 @@
+mambu:
+  host: http://localhost:8043
+  username: test
+  password: test
+validation:
+  rules:
+    location: validations/rules # just a mock location which does nothing

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,7 @@
-
+server:
+  port: 7788
 mambu:
-  host: modusbox.sandbox.mambu.com
+  host: https://modusbox.sandbox.mambu.com
   username: test
   password: test
 

--- a/src/test/resources/io/portx/cbs/connector/cucumber/Person_Tests.feature
+++ b/src/test/resources/io/portx/cbs/connector/cucumber/Person_Tests.feature
@@ -1,0 +1,16 @@
+Feature: Test Person Operations using BDD approach
+
+  Scenario: Create a Person
+    Given I have the person payload located at "test-data/json/mambuAPI/create-person/createPersonRequestOBA.json" that I want to create a person
+    When I create a person using the API
+    Then I check that the status code coming from the API response is "202"
+    And I validate that the API response has the required fields using the validation rules engine
+    And I get the person id
+    And I check that the status code coming from getPerson from the API response is "200"
+    And I validate that the API response from findPerson has the required fields using the validation rules engine
+    And I validate that the fields on the requests are present on the response
+
+  Scenario: Retrieve a Person
+    When I retrieve a person with the id "12345" using the API
+    Then I check that the status code coming from getPerson from the API response is "200"
+    And I validate that the API response from findPerson has the required fields using the validation rules engine

--- a/src/test/resources/test-data/json/mambuAPI/create-person/createPersonRequestMambu.json
+++ b/src/test/resources/test-data/json/mambuAPI/create-person/createPersonRequestMambu.json
@@ -1,0 +1,35 @@
+{
+  "lastName": "Lab",
+  "middleName": "Lab",
+  "firstName": "Vr",
+  "addresses": [
+    {
+      "country": "US",
+      "city": "Chicago",
+      "region": "Illinois",
+      "postcode": "60601",
+      "line1": "123 Main Street, Suite 23"
+    }
+  ],
+  "homePhone": "+1-415-731359",
+  "emailAddress": "string",
+  "gender": "Male",
+  "preferredLanguage": "English",
+  "birthDate": "2022-04-17",
+  "idDocuments": [
+    {
+      "documentId": "111-22-3333",
+      "documentType": "SocialSecurityNumber"
+    },
+    {
+      "documentId": "111111111",
+      "documentType": "SocialSecurityNumber",
+      "issuingAuthority": "US",
+      "validUntil": "2022-04-17"
+    }
+  ],
+  "_searchablefields_Clients": {
+    "townName_Clients": "Chicago",
+    "tIN_Clients": "111-22-3333"
+  }
+}

--- a/src/test/resources/test-data/json/mambuAPI/create-person/createPersonRequestOBA.json
+++ b/src/test/resources/test-data/json/mambuAPI/create-person/createPersonRequestOBA.json
@@ -1,0 +1,214 @@
+{
+  "uSDocumentedIndicator": true,
+  "identifiers": [
+    {
+      "number": "111111111",
+      "schemeName": "SocialSecurityNumber",
+      "issuer": "US",
+      "issueDate": "2022-04-17",
+      "expirationDate": "2022-04-17"
+    }
+  ],
+  "name": "Vr Lab Lab",
+  "shortName": "Vr",
+  "relatedParties": [
+    {
+      "partyId": "5fb9d4d6-1a3c-11ed-861d-0242ac120002",
+      "partyType": "Person",
+      "partyName": "Vr Lab",
+      "partyRelationType": "Owner",
+      "ownershipPercentage": "0.7"
+    }
+  ],
+  "postalAddresses": [
+    {
+      "addressType": "Postal",
+      "addressPurpose": "Billing",
+      "primaryIndicator": true,
+      "department": "A",
+      "subDepartment": "B",
+      "streetName": "Main Street",
+      "firstCrossStreetName": "Elm Street",
+      "secondCrossStreetName": "Oak Street",
+      "buildingNumber": "123",
+      "buildingName": "Chicago Tower",
+      "floor": "10",
+      "postBox": "CHI456",
+      "room": "22",
+      "postCode": "60601",
+      "townName": "Chicago",
+      "townLocationName": "Cook",
+      "districtName": "Illinois",
+      "countrySubDivision": "Cook County",
+      "countrySubDivisionCode": "US-IL",
+      "country": "US",
+      "addressLine": [
+        "123 Main Street, Suite 23"
+      ]
+    }
+  ],
+  "residenceType": "Domestic",
+  "taxInformation": {
+    "tIN": "111-22-3333",
+    "taxIdType": "SocialSecurityNumber",
+    "tINStatus": "Valid",
+    "taxStatus": "Valid",
+    "forms": [
+      {
+        "formName": "W-9",
+        "expirationDate": "2022-04-17"
+      }
+    ],
+    "regulations": [
+      {
+        "name": "Chapter4",
+        "section": "1471"
+      }
+    ],
+    "withholdings": [
+      {
+        "withholdingTaxType": "NonResidentAlienTax",
+        "withholdingRate": "0.7",
+        "withholdingAmount": "100"
+      }
+    ],
+    "countrySubDivision": "Oregon",
+    "countrySubDivisionCode": "AR-B",
+    "country": "US",
+    "supplementaryData": {}
+  },
+  "powerOfAttorney": {
+    "jurisdiction": {
+      "countrySubdivision": "Oregon",
+      "townName": "Tualatin",
+      "country": "US"
+    },
+    "documentId": "5fb9d4d6-1a3c-11ed-861d-0242ac120002",
+    "documentReference": "string",
+    "version": "string",
+    "signOffDate": "2022-04-17",
+    "issueDate": "2022-04-17",
+    "purpose": "string",
+    "fromDateTime": "2022-04-17T08:00:00Z",
+    "upToDateTime": "2022-04-17T08:00:00Z",
+    "authorizedPerson": "5fb9d4d6-1a3c-11ed-861d-0242ac120002",
+    "authorizedAccount": "0dd926fe-1ca2-11ed-861d-0242ac120002"
+  },
+  "supplementaryData": {},
+  "restrictions": [
+    {
+      "name": "externalTransferAllowed",
+      "restrictionPurpose": "This is a description.",
+      "validFrom": "2022-04-17",
+      "validUntil": "2022-04-17"
+    }
+  ],
+  "placeAndDateOfBirth": {
+    "countrySubdivision": "Oregon",
+    "townName": "Tualatin",
+    "country": "US",
+    "birthDate": "2022-04-17"
+  },
+  "contact": {
+    "structuredName": {
+      "firstName": "Vr",
+      "lastName": "Lab"
+
+    },
+    "name": "Vr Lab Lab",
+    "phones": [
+      {
+        "number": "+1-415-731359",
+        "extension": "strin",
+        "phoneType": "string",
+        "phonePurpose": "string",
+        "primaryIndicator": true,
+        "preferredHourOfDay": {
+          "hour": "12",
+          "timeZone": "Pacific"
+        }
+      }
+    ],
+    "emails": [
+      {
+        "emailAddress": "string",
+        "emailPurpose": "Statements",
+        "primaryIndicator": true
+      }
+    ],
+    "jobTitle": "Head of Documentation",
+    "department": "Sales",
+    "preferredMethod": "Email",
+    "preferredLanguage": "English"
+  },
+  "headOfHousehold": true,
+  "civilStatus": "Single",
+  "structuredName": {
+    "firstName": "Vr",
+    "middleName": "Lab",
+    "lastName": "Lab"
+  },
+  "gender": "Male",
+  "profession": "Technology",
+  "jobTitle": "Head of Documentation",
+  "residentialStatus": "Permanent",
+  "minorIndicator": true,
+  "citizenships": [
+    {
+      "country": "US"
+    }
+  ],
+  "countryOfResidence": "US",
+  "profile": {
+    "riskLevel": "Permanent",
+    "creditReview": {
+      "frequency": {
+        "cycle": "Monthly",
+        "every": 999
+      },
+      "lastReviewDate": "2022-04-17T08:00:00Z",
+      "nextReviewDate": "2022-04-17T08:00:00Z",
+      "creditQuality": "UpperMediumGrade",
+      "creditScore": 0
+    },
+    "creditBureauReportCode": "string",
+    "previousFinancialInstitution": "Jane Birkin",
+    "referredByWhom": "Jane Birkin",
+    "moneyLaunderingCheck": "AuthorizedCredit",
+    "knowYourCustomerCheck": "Ordinary",
+    "timeAtCurrentAddress": {
+      "unit": "Months",
+      "value": 999
+    },
+    "sourceOfWealth": "This is a description.",
+    "politicalAffiliation": "string",
+    "lostCustomerDate": "2022-04-17",
+    "lostCustomerReason": "Deceased",
+    "customerConductClassification": "string",
+    "familyMedicalInsuranceIndicator": true,
+    "salaryRange": {
+      "minAmount": "100",
+      "maxAmount": "100"
+    },
+    "employmentStatus": "string",
+    "vIPStatus": "Elite",
+    "employments": [
+      {
+        "employingPartyName": "Jane Birkin",
+        "jobTitle": "Head of Documentation",
+        "employeeTerminationIndicator": false,
+        "lengthOfEmployment": {
+          "unit": "Months",
+          "value": 999
+        },
+        "endDate": "2022-04-17",
+        "place": {
+          "countrySubdivision": "Oregon",
+          "townName": "Tualatin",
+          "country": "US"
+        }
+      }
+    ],
+    "anualIncome": "100"
+  }
+}

--- a/src/test/resources/test-data/json/mambuAPI/create-person/createPersonResponseMambu.json
+++ b/src/test/resources/test-data/json/mambuAPI/create-person/createPersonResponseMambu.json
@@ -1,0 +1,26 @@
+{
+  "encodedKey": "12345",
+  "id": "120281700",
+  "state": "INACTIVE",
+  "creationDate": "2023-08-07T07:48:32-07:00",
+  "lastModifiedDate": "2023-08-07T07:48:32-07:00",
+  "approvedDate": "2023-08-07T07:48:32-07:00",
+  "firstName": "Mary",
+  "lastName": "Smith",
+  "middleName": "Joe",
+  "preferredLanguage": "ENGLISH",
+  "birthDate": "2022-04-17",
+  "clientRoleKey": "8a44cde37b592d63017b5fac6e400518",
+  "loanCycle": 0,
+  "groupLoanCycle": 0,
+  "addresses": [
+    {
+      "encodedKey": "8a44b37889bca9760189c282acae3398",
+      "parentKey": "12345",
+      "line1": "Test",
+      "line2": "Test 2",
+      "indexInList": 0
+    }
+  ],
+  "idDocuments": []
+}

--- a/src/test/resources/test-data/json/mambuAPI/create-person/createPersonResponseOBA.json
+++ b/src/test/resources/test-data/json/mambuAPI/create-person/createPersonResponseOBA.json
@@ -1,0 +1,41 @@
+{
+  "personId": "12345",
+  "identifiers": [
+    {
+      "number": "120281700",
+      "schemeName": "clientId",
+      "issuer": "Mambu"
+    }
+  ],
+  "name": "Mary Joe Smith",
+  "shortName": "Mary Smith",
+  "relatedParties": [
+    {
+      "partyId": "12345",
+      "partyType": "Person",
+      "partyRelationType": "Owner"
+    }
+  ],
+  "postalAddresses": [
+    {
+      "addressLine": [
+        "Test",
+        "Test 2"
+      ]
+    }
+  ],
+  "status": "INACTIVE",
+  "placeAndDateOfBirth": {
+    "birthDate": "2022-04-17"
+  },
+  "structuredName": {
+    "firstName": "Mary",
+    "middleName": "Joe",
+    "lastName": "Smith"
+  },
+  "audit": {
+    "status": "INACTIVE",
+    "creationDate": "2023-08-07",
+    "lastModificationDate": "2023-08-07"
+  }
+}

--- a/src/test/resources/test-data/json/mambuAPI/find-person/findPersonResponseMambu.json
+++ b/src/test/resources/test-data/json/mambuAPI/find-person/findPersonResponseMambu.json
@@ -1,0 +1,26 @@
+{
+  "encodedKey": "12345",
+  "id": "120281700",
+  "state": "INACTIVE",
+  "creationDate": "2023-08-07T07:48:32-07:00",
+  "lastModifiedDate": "2023-08-07T07:48:32-07:00",
+  "approvedDate": "2023-08-07T07:48:32-07:00",
+  "firstName": "Mary",
+  "lastName": "Smith",
+  "middleName": "Joe",
+  "preferredLanguage": "ENGLISH",
+  "birthDate": "2022-04-17",
+  "clientRoleKey": "8a44cde37b592d63017b5fac6e400518",
+  "loanCycle": 0,
+  "groupLoanCycle": 0,
+  "addresses": [
+    {
+      "encodedKey": "8a44b37889bca9760189c282acae3398",
+      "parentKey": "12345",
+      "line1": "Test",
+      "line2": "Test 2",
+      "indexInList": 0
+    }
+  ],
+  "idDocuments": []
+}

--- a/src/test/resources/test-data/json/mambuAPI/find-person/findPersonResponseOBA.json
+++ b/src/test/resources/test-data/json/mambuAPI/find-person/findPersonResponseOBA.json
@@ -1,0 +1,41 @@
+{
+  "personId": "12345",
+  "identifiers": [
+    {
+      "number": "120281700",
+      "schemeName": "clientId",
+      "issuer": "Mambu"
+    }
+  ],
+  "name": "Mary Joe Smith",
+  "shortName": "Mary Smith",
+  "relatedParties": [
+    {
+      "partyId": "12345",
+      "partyType": "Person",
+      "partyRelationType": "Owner"
+    }
+  ],
+  "postalAddresses": [
+    {
+      "addressLine": [
+        "Test",
+        "Test 2"
+      ]
+    }
+  ],
+  "status": "INACTIVE",
+  "placeAndDateOfBirth": {
+    "birthDate": "2022-04-17"
+  },
+  "structuredName": {
+    "firstName": "Mary",
+    "middleName": "Joe",
+    "lastName": "Smith"
+  },
+  "audit": {
+    "status": "INACTIVE",
+    "creationDate": "2023-08-07",
+    "lastModificationDate": "2023-08-07"
+  }
+}


### PR DESCRIPTION
Added cucumber tests for moov-fintech

## Aditional information

### Changed url path from properties

For working with cucumber without https, I removed https as part of url path on mambu routes and added that in the properties.

### Smaller changes in the mappings for preventing integration break.

The only change made for being complant with new swagger version was a date format in the person creation and getPerson, no field name change.

### Cucumber implementation without considering new mappings changes

This cucumber implementation is not considering the swagger update fields, for that reason its just for this branch and should not be considered as a main change.

### Cucumber reports

Cucumber reports now is offline, that is meaning it is not generating a url of cucumber results when tests is running, if it is needed we can adjust.

### PR check
Updated `pr-validation.yml` file for having this branch as a pr checker and we can see the cucumber tests running.